### PR TITLE
Revert "Bump spring-boot-starter-parent from 2.5.6 to 2.7.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.5.6</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
Reverts StevenMassaro/music#9

This is being reverted because it is breaking CORS interactions when deployed locally.